### PR TITLE
Add :arguments-as-list option to support functions with &rest parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,56 @@
 Get command and options from command line arguments.\
 This library is intended for use in cli programs with commands and options, such as `rails` or `docker` commands.
 
+This library is particularly useful for creating Roswell scripts that need to parse command line arguments.
+
 # usage
+
+## Roswell script example
+
+This is a simple example of using getcmd in a Roswell script:
+
+```common-lisp
+#!/bin/sh
+#|-*- mode:lisp -*-|#
+#|
+exec ros -Q -- $0 "$@"
+|#
+
+(ql:quickload :getcmd :silent t)
+
+(defun hello (name &key greeting)
+  (format t "~A, ~A!~%" (or greeting "Hello") name))
+
+(defun goodbye (name)
+  (format t "Goodbye, ~A!~%" name))
+
+(defparameter *config*
+  `(:commands ((:command "hello"
+                :function ,#'hello
+                :options ((:short-option "g"
+                           :long-option "greeting"
+                           :keyword :greeting
+                           :consume t)))
+               (:command "goodbye"
+                :function ,#'goodbye))))
+
+(defun main (&rest argv)
+  (let ((c (getcmd:getcmd argv *config*)))
+    (when (getf c :function)
+      (apply (getf c :function) (getf c :args)))))
+```
+
+Usage:
+```bash
+$ ./script.ros hello World
+Hello, World!
+
+$ ./script.ros hello World --greeting Hi
+Hi, World!
+
+$ ./script.ros goodbye World
+Goodbye, World!
+```
 
 ## define functions
 
@@ -99,6 +148,7 @@ command-def := :command string
              | :commands command-list
              | :function function
              | :options option-list
+             | :arguments-as-list [ T | nil ]
 
 
 option-list := ( option-def * )
@@ -245,6 +295,83 @@ If `:converter` is specified with `:multiple`, the converter is applied to each 
 ;; Usage:
 ;; cmd --num 1 --num 2 -n 3
 ;; => :num-list (1 2 3)
+```
+
+## `:arguments-as-list`
+
+- type: T or NIL
+
+If T, all positional arguments are collected into a single list before being passed to the function.
+This is useful when the function has a `&rest` parameter or expects a list of arguments as its first parameter.
+
+When `:arguments-as-list` is nil or not specified (default), positional arguments
+are passed individually as they have been.
+
+### Background
+
+In CLI applications, it's common to write functions that accept a variable number of files or items:
+
+```common-lisp
+(defun show-files (files &key verbose)
+  ;; files is expected to be a list
+  (loop for file in files
+        do (format t "~A~%" file)))
+```
+
+Without `:arguments-as-list`, positional arguments would be passed individually:
+```common-lisp
+;; cmd show-files file1.txt file2.txt
+;; => (show-files "file1.txt" "file2.txt")  ; Error: too many arguments
+```
+
+With `:arguments-as-list t`, all positional arguments are collected into a list:
+```common-lisp
+;; cmd show-files file1.txt file2.txt
+;; => (show-files ("file1.txt" "file2.txt"))  ; Correct!
+```
+
+This makes it easy to handle commands that process multiple items without having to manually collect them.
+
+### Example with `:arguments-as-list t`:
+
+```common-lisp
+(defun show-files (files &key verbose)
+  (loop for file in files
+        do (if verbose
+               (format t "File: ~A~%" file)
+               (format t "~A~%" file))))
+
+(defparameter *config*
+  `(:commands ((:command "show-files"
+                :function ,#'show-files
+                :arguments-as-list t
+                :options ((:short-option "v"
+                           :long-option "verbose"
+                           :keyword :verbose
+                           :consume nil))))))
+
+;; Usage:
+;; cmd show-files --verbose file1.txt file2.txt
+;; => (show-files ("file1.txt" "file2.txt") :verbose t)
+
+;; With no files:
+;; cmd show-files --verbose
+;; => (show-files nil :verbose t)
+```
+
+### Example without `:arguments-as-list` (default):
+
+```common-lisp
+(defun add (x y)
+  (+ (parse-integer x) (parse-integer y)))
+
+(defparameter *config*
+  `(:commands ((:command "add"
+                :function ,#'add))))
+
+;; Usage:
+;; cmd add 3 4
+;; => (add "3" "4")
 ```
 
 # Copyright

--- a/getcmd-test.lisp
+++ b/getcmd-test.lisp
@@ -327,3 +327,73 @@
     (ok (signals (getcmd '("test" "--flag") *invalid-multiple-config*) 'error))))
 
 
+(defun args-list-test-func (args &key key1)
+  (list args key1))
+
+(defparameter *args-list-config*
+  `(:commands ((:command "test"
+                :function ,#'args-list-test-func
+                :arguments-as-list t
+                :options ((:long-option "key1"
+                           :keyword :key1
+                           :consume t))))))
+
+(deftest arguments-as-list-test
+  (testing "no parameters with option"
+    (let ((c (getcmd '("test" "--key1" "val") *args-list-config*)))
+      (ok (eq #'args-list-test-func (getf c :function)))
+      (ok (equal '(nil :key1 "val") (getf c :args)))
+      (ok (equal '(nil "val") (apply (getf c :function) (getf c :args))))))
+
+  (testing "one parameter with option"
+    (let ((c (getcmd '("test" "arg1" "--key1" "val") *args-list-config*)))
+      (ok (eq #'args-list-test-func (getf c :function)))
+      (ok (equal '(("arg1") :key1 "val") (getf c :args)))
+      (ok (equal '(("arg1") "val") (apply (getf c :function) (getf c :args))))))
+
+  (testing "multiple parameters with option"
+    (let ((c (getcmd '("test" "arg1" "arg2" "--key1" "val") *args-list-config*)))
+      (ok (eq #'args-list-test-func (getf c :function)))
+      (ok (equal '(("arg1" "arg2") :key1 "val") (getf c :args)))
+      (ok (equal '(("arg1" "arg2") "val") (apply (getf c :function) (getf c :args))))))
+
+  (testing "parameters only (no options)"
+    (let ((c (getcmd '("test" "arg1" "arg2") *args-list-config*)))
+      (ok (eq #'args-list-test-func (getf c :function)))
+      (ok (equal '(("arg1" "arg2")) (getf c :args)))
+      (ok (equal '(("arg1" "arg2") nil) (apply (getf c :function) (getf c :args))))))
+
+  (testing "no parameters and no options"
+    (let ((c (getcmd '("test") *args-list-config*)))
+      (ok (eq #'args-list-test-func (getf c :function)))
+      (ok (equal '(nil) (getf c :args)))
+      (ok (equal '(nil nil) (apply (getf c :function) (getf c :args)))))))
+
+
+(defun args-list-multiple-test-func (args &key exclude)
+  (list args exclude))
+
+(defparameter *args-list-multiple-config*
+  `(:commands ((:command "test"
+                :function ,#'args-list-multiple-test-func
+                :arguments-as-list t
+                :options ((:long-option "exclude"
+                           :keyword :exclude
+                           :consume t
+                           :multiple t))))))
+
+(deftest arguments-as-list-with-multiple-test
+  (testing "arguments-as-list with multiple option"
+    (let ((c (getcmd '("test" "arg1" "--exclude" "*.tmp" "--exclude" "*.bak") *args-list-multiple-config*)))
+      (ok (eq #'args-list-multiple-test-func (getf c :function)))
+      (ok (equal '(("arg1") :exclude ("*.tmp" "*.bak")) (getf c :args)))
+      (ok (equal '(("arg1") ("*.tmp" "*.bak")) (apply (getf c :function) (getf c :args))))))
+
+  (testing "arguments-as-list with multiple parameters and multiple option"
+    (let ((c (getcmd '("test" "arg1" "arg2" "--exclude" "*.tmp" "--exclude" "*.bak") *args-list-multiple-config*)))
+      (ok (eq #'args-list-multiple-test-func (getf c :function)))
+      (ok (equal '(("arg1" "arg2") :exclude ("*.tmp" "*.bak")) (getf c :args)))
+      (ok (equal '(("arg1" "arg2") ("*.tmp" "*.bak")) (apply (getf c :function) (getf c :args)))))))
+
+
+

--- a/getcmd.lisp
+++ b/getcmd.lisp
@@ -19,6 +19,7 @@
 (defparameter *function* nil)
 (defparameter *arguments* nil)
 (defparameter *options* nil)
+(defparameter *current-command-config* nil)
 
 
 (defun process-multiple-options (options)
@@ -34,7 +35,8 @@
 (defun getcmd (args config &optional default-function)
   (let ((*function* nil)
         (*arguments* nil)
-        (*options* nil))
+        (*options* nil)
+        (*current-command-config* nil))
     (eval/cmd-option-arg args config)
     (let ((fn (if *function*
                   (if (stringp *function*)
@@ -43,7 +45,11 @@
                   default-function))
           (processed-options (process-multiple-options *options*)))
       `(:function ,fn
-        :args ,(append *arguments* processed-options)))))
+        :args ,(if (getf *current-command-config* :arguments-as-list)
+                   ;; arguments-as-list: 位置引数をリストにまとめる
+                   (cons *arguments* processed-options)
+                   ;; 通常: 位置引数を展開
+                   (append *arguments* processed-options))))))
 
 
 ;; ----------------------------------------
@@ -80,6 +86,7 @@
                         return cmd)))
     (assert cmdopt)
     (setf *function* (getf cmdopt :function))
+    (setf *current-command-config* cmdopt)
     (eval/cmd-option-arg (cdr args) cmdopt)))
 
 

--- a/getcmd.lisp
+++ b/getcmd.lisp
@@ -46,9 +46,9 @@
           (processed-options (process-multiple-options *options*)))
       `(:function ,fn
         :args ,(if (getf *current-command-config* :arguments-as-list)
-                   ;; arguments-as-list: 位置引数をリストにまとめる
+                   ;; arguments-as-list: collect positional arguments into a list
                    (cons *arguments* processed-options)
-                   ;; 通常: 位置引数を展開
+                   ;; normal: expand positional arguments
                    (append *arguments* processed-options))))))
 
 


### PR DESCRIPTION
## Summary

This PR adds the `:arguments-as-list` option to command configuration, allowing all positional arguments to be collected into a single list before being passed
 to the function. This feature is essential for CLI applications that need to process variable numbers of files or items.

## Motivation

In CLI applications, it's common to write functions that accept a variable number of items:

```common-lisp
(defun show-files (files &key verbose)
  (loop for file in files
        do (format t "~A~%" file)))
```

However, without `:arguments-as-list`, getcmd passes positional arguments individually, causing errors:

```bash
$ cmd show-files file1.txt file2.txt
```

This would try to call `(show-files "file1.txt" "file2.txt")`, resulting in a "too many arguments" error because `show-files` expects a single list as the firs
t parameter.

This pattern is very common in CLI tools:
- `grep pattern file1 file2 file3` - process multiple files
- `rm file1 file2 file3` - delete multiple files
- `cp source1 source2 dest` - copy multiple sources

## Solution

With `:arguments-as-list t`, all positional arguments are automatically collected into a list:

```common-lisp
(:command "show-files"
 :function #'show-files
 :arguments-as-list t
 :options (...))
```

Now the same command works correctly:

```bash
$ cmd show-files file1.txt file2.txt
# => (show-files ("file1.txt" "file2.txt"))  ✓ Correct!
```

When no positional arguments are provided, `nil` is passed:

```bash
$ cmd show-files --verbose
# => (show-files nil :verbose t)
```

## Changes

### Implementation

1. **Added `*current-command-config*` special variable**
   - Tracks the current command configuration during parsing
   - Set by `apply/cmd` when a command is matched

2. **Modified `getcmd` function**
   - Checks `:arguments-as-list` in the current command configuration
   - Uses `(cons *arguments* processed-options)` when true
   - Uses `(append *arguments* processed-options)` when false (default)

3. **Modified `apply/cmd` function**
   - Sets `*current-command-config*` to the matched command configuration

### Code Changes

**getcmd.lisp**:
- Added `*current-command-config*` special variable
- Updated `getcmd` to handle `:arguments-as-list` option
- Updated `apply/cmd` to track current command configuration

**getcmd-test.lisp**:
- Added `arguments-as-list-test` with 5 test cases:
  - No parameters with option
  - One parameter with option
  - Multiple parameters with option
  - Parameters only (no options)
  - No parameters and no options
- Added `arguments-as-list-with-multiple-test` with 2 test cases:
  - Combination with `:multiple` option
  - Multiple parameters with `:multiple` option

## Examples

### Basic Usage

```common-lisp
(defun show-files (files &key verbose)
  (loop for file in files
        do (if verbose
               (format t "File: ~A~%" file)
               (format t "~A~%" file))))

(defparameter *config*
  `(:commands ((:command "show-files"
                :function ,#'show-files
                :arguments-as-list t
                :options ((:short-option "v"
                           :long-option "verbose"
                           :keyword :verbose
                           :consume nil))))))
```

Command line usage:
```bash
$ cmd show-files --verbose file1.txt file2.txt file3.txt
# => (show-files ("file1.txt" "file2.txt" "file3.txt") :verbose t)
```

### With :multiple Option

The `:arguments-as-list` option works seamlessly with `:multiple`:

```common-lisp
(defun process-files (files &key exclude)
  ;; files is a list of filenames
  ;; exclude is a list of patterns (from :multiple)
  ...)

(defparameter *config*
  `(:commands ((:command "process"
                :function ,#'process-files
                :arguments-as-list t
                :options ((:long-option "exclude"
                           :keyword :exclude
                           :consume t
                           :multiple t))))))
```

Command line usage:
```bash
$ cmd process src/*.lisp --exclude test --exclude backup
# => (process-files ("src/foo.lisp" "src/bar.lisp") :exclude ("test" "backup"))
```

## Testing

All tests pass, including:

### New Tests

1. **arguments-as-list-test** (5 cases)
   - ✅ No parameters with option → `(nil :key "val")`
   - ✅ One parameter with option → `(("arg1") :key "val")`
   - ✅ Multiple parameters with option → `(("arg1" "arg2") :key "val")`
   - ✅ Parameters only (no options) → `(("arg1" "arg2"))`
   - ✅ No parameters and no options → `(nil)`

2. **arguments-as-list-with-multiple-test** (2 cases)
   - ✅ With `:multiple` option
   - ✅ Multiple parameters with `:multiple` option

### Existing Tests

All existing tests continue to pass, confirming backward compatibility.

```bash
$ make test
✓ 1 test completed
Summary:
  All 1 test passed.
```

## Backward Compatibility

✅ **Fully backward compatible**

When `:arguments-as-list` is not specified or is `nil`, positional arguments are passed individually as before:

```common-lisp
(defun add (x y)
  (+ (parse-integer x) (parse-integer y)))

;; No :arguments-as-list specified
(:command "add" :function #'add)

;; cmd add 3 4
;; => (add "3" "4")  ✓ Works as before
```

All existing code continues to work without any changes.

## Related Work

This feature complements the existing `:multiple` option:
- `:multiple`: Collects multiple occurrences of the same **option** into a list
- `:arguments-as-list`: Collects multiple **positional arguments** into a list

Both can be used together effectively for complex CLI applications.

